### PR TITLE
Support negative gamerule values

### DIFF
--- a/src/main/java/se/gory_moon/globalgamerules/Config.java
+++ b/src/main/java/se/gory_moon/globalgamerules/Config.java
@@ -156,7 +156,7 @@ public class Config {
                                     .define(name, booleanValue.get()));
                         } else {
                             gameRules.put(ruleKey, ruleBuilder
-                                    .defineInRange(name, ((GameRules.IntegerValue) t).get(), 0, Integer.MAX_VALUE));
+                                    .defineInRange(name, ((GameRules.IntegerValue) t).get(), Integer.MIN_VALUE, Integer.MAX_VALUE));
                         }
 
                         // Pop the category


### PR DESCRIPTION
Even if vanilla game rules don't support negative values, we support them as the user can set the value to negative.
The usage of the game rules checks the validity where it's used, and some mods might use negative values. 

Fixed #22 